### PR TITLE
FEATURE + FIX: Multi Window support and temperature restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+
+## v1.1.28
+- Fix: multiple window sensors now normalized so all selected sensors trigger
+- Fix: window close triggers forced update (cooldown no longer blocks forced control)
+
+
+## v1.1.27
+- Migration: automatically convert legacy window_sensor_entity to window_sensor_entities (multi window sensors)
+
+
 ## v1.1.22
 - Fix: when starting inside deadband and last_set is unknown, initialize TRV setpoint to baseline
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This approach ensures **broad compatibility** across different manufacturers, pr
 - 🌡️ Uses an external temperature sensor for accurate room temperature
 - 🎯 Virtual climate entity (usable in dashboards and HomeKit)
 - 🧠 Adaptive learning without aggressive oscillation
-- 🪟 Window sensor support (automatic setback)
+- 🪟 Multi Window sensor support (automatic setback)
 - 🚀 Boost mode (temporary full heating)
 - ♻️ Reset learned offset at any time
 - 🧊 Adaptive over-temperature correction
@@ -56,8 +56,9 @@ Default values (configurable):
 
 ---
 
-## 🪟 Window Sensor
+## 🪟 Multi Window Sensor
 
+- Define multiple window sensors
 - Window open → thermostat set to minimum
 - Window closed → target restored immediately
 - Learning is paused while the window is open

--- a/custom_components/smart_offset_thermostat/const.py
+++ b/custom_components/smart_offset_thermostat/const.py
@@ -41,6 +41,7 @@ SIGNAL_UPDATE = "smart_offset_thermostat_update"
 
 
 CONF_WINDOW_SENSOR = "window_sensor_entity"
+CONF_WINDOW_SENSORS = "window_sensor_entities"
 CONF_BOOST_DURATION_SEC = "boost_duration_sec"
 
 DEFAULT_BOOST_DURATION_SEC = 300

--- a/custom_components/smart_offset_thermostat/manifest.json
+++ b/custom_components/smart_offset_thermostat/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/fabilau/hass_smart_offset_thermostat/issues",
   "requirements": [],
-  "version": "1.1.25"
+  "version": "1.1.28"
 }

--- a/custom_components/smart_offset_thermostat/strings.json
+++ b/custom_components/smart_offset_thermostat/strings.json
@@ -9,7 +9,7 @@
           "climate_entity": "Thermostat",
           "room_sensor_entity": "Room temperature sensor",
           "room_target": "Room target temperature",
-          "window_sensor_entity": "Window sensor (binary_sensor, optional)"
+          "window_sensor_entities": "Window sensors (optional, multiple)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Cooldown between changes (seconds)",
           "enable_learning": "Enable learning",
           "boost_duration_sec": "Boost duration (seconds)",
-          "window_sensor_entity": "Window sensor (binary_sensor, optional)",
           "stuck_enable": "Adaptive over-temp correction (reduce setpoint if room stays too warm)",
           "stuck_seconds": "Over-temp evaluation window (seconds)",
           "stuck_min_drop": "Required cooling within window (°C)",
-          "stuck_step": "Extra reduction step when too warm (°C)"
+          "stuck_step": "Extra reduction step when too warm (°C)",
+          "window_sensor_entities": "Window sensors (optional, multiple)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/de.json
+++ b/custom_components/smart_offset_thermostat/translations/de.json
@@ -9,7 +9,7 @@
           "climate_entity": "Thermostat",
           "room_sensor_entity": "Externer Raumtemperatur-Sensor",
           "room_target": "Raum-Solltemperatur",
-          "window_sensor_entity": "Fenstersensor (binary_sensor, optional)"
+          "window_sensor_entities": "Fenstersensor (binary_sensor, optional)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Sperrzeit zwischen Änderungen (Sekunden)",
           "enable_learning": "Lernen aktivieren",
           "boost_duration_sec": "Boost-Dauer (Sekunden)",
-          "window_sensor_entity": "Fenstersensor (binary_sensor, optional)",
           "stuck_enable": "Adaptive Übertemperatur-Korrektur (senkt Sollwert, wenn Raum zu warm bleibt)",
           "stuck_seconds": "Übertemperatur-Auswertefenster (Sekunden)",
           "stuck_min_drop": "Erforderliche Abkühlung im Fenster (°C)",
-          "stuck_step": "Zusätzlicher Absenk-Schritt bei Übertemperatur (°C)"
+          "stuck_step": "Zusätzlicher Absenk-Schritt bei Übertemperatur (°C)",
+          "window_sensor_entities": "Fenstersensor (binary_sensor, optional)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/en.json
+++ b/custom_components/smart_offset_thermostat/translations/en.json
@@ -8,8 +8,8 @@
         "data": {
           "climate_entity": "Thermostat",
           "room_sensor_entity": "External room temperature sensor",
-          "window_sensor_entity": "Window sensor (binary_sensor, optional)",
-          "room_target": "Room target temperature"
+          "room_target": "Room target temperature",
+          "window_sensor_entities": "Window sensor (binary_sensor, optional)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Cooldown between changes (seconds)",
           "boost_duration_sec": "Boost duration (seconds)",
           "enable_learning": "Enable learning",
-          "window_sensor_entity": "Window sensor (binary_sensor, optional)",
           "stuck_enable": "Adaptive over-temp correction (reduce setpoint if room stays too warm)",
           "stuck_seconds": "Over-temp evaluation window (seconds)",
           "stuck_min_drop": "Required cooling within window (°C)",
-          "stuck_step": "Extra reduction step when too warm (°C)"
+          "stuck_step": "Extra reduction step when too warm (°C)",
+          "window_sensor_entities": "Window sensor (binary_sensor, optional)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/es.json
+++ b/custom_components/smart_offset_thermostat/translations/es.json
@@ -8,8 +8,8 @@
         "data": {
           "climate_entity": "Termostato",
           "room_sensor_entity": "Sensor externo de temperatura de la habitación",
-          "window_sensor_entity": "Sensor de ventana (binary_sensor, opcional)",
-          "room_target": "Temperatura objetivo de la habitación"
+          "room_target": "Temperatura objetivo de la habitación",
+          "window_sensor_entities": "Sensor de ventana (binary_sensor, opcional)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Enfriamiento entre cambios (segundos)",
           "boost_duration_sec": "Duración del boost (segundos)",
           "enable_learning": "Habilitar aprendizaje",
-          "window_sensor_entity": "Sensor de ventana (binary_sensor, opcional)",
           "stuck_enable": "Corrección adaptativa de sobretemperatura (baja la consigna si la habitación sigue demasiado caliente)",
           "stuck_seconds": "Ventana de evaluación de sobretemperatura (segundos)",
           "stuck_min_drop": "Enfriamiento requerido en la ventana (°C)",
-          "stuck_step": "Paso extra de reducción en sobretemperatura (°C)"
+          "stuck_step": "Paso extra de reducción en sobretemperatura (°C)",
+          "window_sensor_entities": "Sensor de ventana (binary_sensor, opcional)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/fr.json
+++ b/custom_components/smart_offset_thermostat/translations/fr.json
@@ -8,8 +8,8 @@
         "data": {
           "climate_entity": "Thermostat",
           "room_sensor_entity": "Capteur externe de température de la pièce",
-          "window_sensor_entity": "Capteur de fenêtre (binary_sensor, optionnel)",
-          "room_target": "Température cible de la pièce"
+          "room_target": "Température cible de la pièce",
+          "window_sensor_entities": "Capteur de fenêtre (binary_sensor, optionnel)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Temps de blocage entre changements (secondes)",
           "boost_duration_sec": "Durée du boost (secondes)",
           "enable_learning": "Activer l’apprentissage",
-          "window_sensor_entity": "Capteur de fenêtre (binary_sensor, optionnel)",
           "stuck_enable": "Correction adaptative de surchauffe (baisse la consigne si la pièce reste trop chaude)",
           "stuck_seconds": "Fenêtre d’évaluation surchauffe (secondes)",
           "stuck_min_drop": "Refroidissement requis dans la fenêtre (°C)",
-          "stuck_step": "Pas de baisse supplémentaire en surchauffe (°C)"
+          "stuck_step": "Pas de baisse supplémentaire en surchauffe (°C)",
+          "window_sensor_entities": "Capteur de fenêtre (binary_sensor, optionnel)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/it.json
+++ b/custom_components/smart_offset_thermostat/translations/it.json
@@ -8,8 +8,8 @@
         "data": {
           "climate_entity": "Termostato",
           "room_sensor_entity": "Sensore esterno temperatura stanza",
-          "window_sensor_entity": "Sensore finestra (binary_sensor, opzionale)",
-          "room_target": "Temperatura obiettivo stanza"
+          "room_target": "Temperatura obiettivo stanza",
+          "window_sensor_entities": "Sensore finestra (binary_sensor, opzionale)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Pausa tra modifiche (secondi)",
           "boost_duration_sec": "Durata boost (secondi)",
           "enable_learning": "Abilita apprendimento",
-          "window_sensor_entity": "Sensore finestra (binary_sensor, opzionale)",
           "stuck_enable": "Correzione adattiva sovratemperatura (abbassa il setpoint se la stanza resta troppo calda)",
           "stuck_seconds": "Finestra valutazione sovratemperatura (secondi)",
           "stuck_min_drop": "Raffreddamento richiesto nella finestra (°C)",
-          "stuck_step": "Passo extra di riduzione in sovratemperatura (°C)"
+          "stuck_step": "Passo extra di riduzione in sovratemperatura (°C)",
+          "window_sensor_entities": "Sensore finestra (binary_sensor, opzionale)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/nl.json
+++ b/custom_components/smart_offset_thermostat/translations/nl.json
@@ -8,8 +8,8 @@
         "data": {
           "climate_entity": "Thermostaat",
           "room_sensor_entity": "Externe kamertemperatuursensor",
-          "window_sensor_entity": "Raamsensor (binary_sensor, optioneel)",
-          "room_target": "Doeltemperatuur kamer"
+          "room_target": "Doeltemperatuur kamer",
+          "window_sensor_entities": "Raamsensor (binary_sensor, optioneel)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Wachttijd tussen wijzigingen (seconden)",
           "boost_duration_sec": "Boostduur (seconden)",
           "enable_learning": "Leren inschakelen",
-          "window_sensor_entity": "Raamsensor (binary_sensor, optioneel)",
           "stuck_enable": "Adaptieve overtemperatuur-correctie (verlaagt setpoint als de kamer te warm blijft)",
           "stuck_seconds": "Evaluatievenster overtemperatuur (seconden)",
           "stuck_min_drop": "Benodigde afkoeling in venster (°C)",
-          "stuck_step": "Extra verlaagstap bij overtemperatuur (°C)"
+          "stuck_step": "Extra verlaagstap bij overtemperatuur (°C)",
+          "window_sensor_entities": "Raamsensor (binary_sensor, optioneel)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/no.json
+++ b/custom_components/smart_offset_thermostat/translations/no.json
@@ -8,8 +8,8 @@
         "data": {
           "climate_entity": "Termostat",
           "room_sensor_entity": "Ekstern romtemperatursensor",
-          "window_sensor_entity": "Vindussensor (binary_sensor, valgfri)",
-          "room_target": "Ønsket romtemperatur"
+          "room_target": "Ønsket romtemperatur",
+          "window_sensor_entities": "Vindussensor (binary_sensor, valgfri)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Sperretid mellom endringer (sekunder)",
           "boost_duration_sec": "Boost-varighet (sekunder)",
           "enable_learning": "Aktiver læring",
-          "window_sensor_entity": "Vindussensor (binary_sensor, valgfri)",
           "stuck_enable": "Adaptiv overtemperatur-korrigering (senker settpunkt hvis rommet forblir for varmt)",
           "stuck_seconds": "Evalueringsvindu for overtemperatur (sekunder)",
           "stuck_min_drop": "Krav til nedkjøling i vinduet (°C)",
-          "stuck_step": "Ekstra senkesteg ved overtemperatur (°C)"
+          "stuck_step": "Ekstra senkesteg ved overtemperatur (°C)",
+          "window_sensor_entities": "Vindussensor (binary_sensor, valgfri)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/pl.json
+++ b/custom_components/smart_offset_thermostat/translations/pl.json
@@ -8,8 +8,8 @@
         "data": {
           "climate_entity": "Termostat",
           "room_sensor_entity": "Zewnętrzny czujnik temperatury pomieszczenia",
-          "window_sensor_entity": "Czujnik okna (binary_sensor, opcjonalnie)",
-          "room_target": "Temperatura docelowa pomieszczenia"
+          "room_target": "Temperatura docelowa pomieszczenia",
+          "window_sensor_entities": "Czujnik okna (binary_sensor, opcjonalnie)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Czas blokady między zmianami (sekundy)",
           "boost_duration_sec": "Czas boost (sekundy)",
           "enable_learning": "Włącz uczenie",
-          "window_sensor_entity": "Czujnik okna (binary_sensor, opcjonalnie)",
           "stuck_enable": "Adaptacyjna korekta przegrzania (obniża nastawę, jeśli pomieszczenie pozostaje zbyt ciepłe)",
           "stuck_seconds": "Okno oceny przegrzania (sekundy)",
           "stuck_min_drop": "Wymagane schłodzenie w oknie (°C)",
-          "stuck_step": "Dodatkowy krok obniżenia przy przegrzaniu (°C)"
+          "stuck_step": "Dodatkowy krok obniżenia przy przegrzaniu (°C)",
+          "window_sensor_entities": "Czujnik okna (binary_sensor, opcjonalnie)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/pt-BR.json
+++ b/custom_components/smart_offset_thermostat/translations/pt-BR.json
@@ -8,8 +8,8 @@
         "data": {
           "climate_entity": "Termostato",
           "room_sensor_entity": "Sensor externo de temperatura do ambiente",
-          "window_sensor_entity": "Sensor de janela (binary_sensor, opcional)",
-          "room_target": "Temperatura alvo do ambiente"
+          "room_target": "Temperatura alvo do ambiente",
+          "window_sensor_entities": "Sensor de janela (binary_sensor, opcional)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Pausa entre mudanças (segundos)",
           "boost_duration_sec": "Duração do boost (segundos)",
           "enable_learning": "Ativar aprendizado",
-          "window_sensor_entity": "Sensor de janela (binary_sensor, opcional)",
           "stuck_enable": "Correção adaptativa de sobretemperatura (reduz a meta se o ambiente continuar quente demais)",
           "stuck_seconds": "Janela de avaliação de sobretemperatura (segundos)",
           "stuck_min_drop": "Resfriamento necessário na janela (°C)",
-          "stuck_step": "Passo extra de redução em sobretemperatura (°C)"
+          "stuck_step": "Passo extra de redução em sobretemperatura (°C)",
+          "window_sensor_entities": "Sensor de janela (binary_sensor, opcional)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/pt.json
+++ b/custom_components/smart_offset_thermostat/translations/pt.json
@@ -8,8 +8,8 @@
         "data": {
           "climate_entity": "Termóstato",
           "room_sensor_entity": "Sensor externo de temperatura da divisão",
-          "window_sensor_entity": "Sensor de janela (binary_sensor, opcional)",
-          "room_target": "Temperatura alvo da divisão"
+          "room_target": "Temperatura alvo da divisão",
+          "window_sensor_entities": "Sensor de janela (binary_sensor, opcional)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Tempo de espera entre alterações (segundos)",
           "boost_duration_sec": "Duração do boost (segundos)",
           "enable_learning": "Ativar aprendizagem",
-          "window_sensor_entity": "Sensor de janela (binary_sensor, opcional)",
           "stuck_enable": "Correção adaptativa de sobretemperatura (reduz a consigna se a divisão continuar demasiado quente)",
           "stuck_seconds": "Janela de avaliação de sobretemperatura (segundos)",
           "stuck_min_drop": "Arrefecimento necessário na janela (°C)",
-          "stuck_step": "Passo extra de redução em sobretemperatura (°C)"
+          "stuck_step": "Passo extra de redução em sobretemperatura (°C)",
+          "window_sensor_entities": "Sensor de janela (binary_sensor, opcional)"
         }
       }
     }

--- a/custom_components/smart_offset_thermostat/translations/sv.json
+++ b/custom_components/smart_offset_thermostat/translations/sv.json
@@ -8,8 +8,8 @@
         "data": {
           "climate_entity": "Termostat",
           "room_sensor_entity": "Extern rumstemperatursensor",
-          "window_sensor_entity": "Fönstersensor (binary_sensor, valfri)",
-          "room_target": "Måltemperatur för rummet"
+          "room_target": "Måltemperatur för rummet",
+          "window_sensor_entities": "Fönstersensor (binary_sensor, valfri)"
         }
       }
     }
@@ -30,11 +30,11 @@
           "cooldown_sec": "Spärrtid mellan ändringar (sekunder)",
           "boost_duration_sec": "Boostlängd (sekunder)",
           "enable_learning": "Aktivera inlärning",
-          "window_sensor_entity": "Fönstersensor (binary_sensor, valfri)",
           "stuck_enable": "Adaptiv övertemperatur-korrigering (sänker börvärdet om rummet förblir för varmt)",
           "stuck_seconds": "Utvärderingsfönster övertemperatur (sekunder)",
           "stuck_min_drop": "Krav på nedkylning i fönstret (°C)",
-          "stuck_step": "Extra sänkningssteg vid övertemperatur (°C)"
+          "stuck_step": "Extra sänkningssteg vid övertemperatur (°C)",
+          "window_sensor_entities": "Fönstersensor (binary_sensor, valfri)"
         }
       }
     }


### PR DESCRIPTION
### ✨ Features

This PR introduces **multi-window support** for open window detection, allowing the thermostat to react to **multiple open windows simultaneously** and reduce the temperature accordingly.

### ✨ Improvements

- Reworked open window handling from **single-window** to **multi-window support**
- Temperature reduction is now applied as long as **at least one configured window remains open**
- Improved overall logic for window-based temperature offsets

### 🐛 Fixes

- Fixed an issue where the temperature **remained at the minimum value** after all windows were closed
- The previous target temperature is now **restored correctly once all windows are closed**